### PR TITLE
datos duplicados

### DIFF
--- a/ecommerce/reservaciones/views.py
+++ b/ecommerce/reservaciones/views.py
@@ -21,6 +21,7 @@ def generar_codigo_reserva():
     return ''.join(random.choices(string.ascii_uppercase + string.digits, k=6))
 
 
+
 def reservacion(request):
     # Generar los próximos cinco días para el selector de días
     days = [(timezone.now() + timedelta(days=i)).strftime('%Y-%m-%d') for i in range(1, 6)]
@@ -54,7 +55,7 @@ def reservacion(request):
         except ValidationError:
             return JsonResponse({'error': 'Correo electrónico no es válido.'}, status=400)
 
-        # Verificar si la mesa está ocupada para el día y hora seleccionados
+        # Verificar si la mesa ya está ocupada para el día y hora seleccionados
         reserva_existente = Reserva.objects.filter(
             numero_mesa=numero_mesa,
             dia_reserva=dia_reserva,
@@ -65,6 +66,15 @@ def reservacion(request):
             return JsonResponse({
                 'error': 'mesa_ocupada',
                 'error_msg': "¡Lo sentimos! pero la mesa que intentas reservar ya está reservada."
+            }, status=400)
+
+        # Verificar si el correo ya ha realizado una reserva, independientemente de la mesa, hora o día
+        correo_existente = Reserva.objects.filter(email=email).exists()
+
+        if correo_existente:
+            return JsonResponse({
+                'error': 'correo_existente',
+                'error_msg': "¡Lo sentimos! El correo electrónico ingresado ya ha realizado una reserva previamente."
             }, status=400)
 
         # Generar código de reserva
@@ -110,7 +120,6 @@ def reservacion(request):
 
     # Renderizar la página de reservaciones
     return render(request, 'reservaciones/reservacion.html', {'days': days})
-
 
 
 @csrf_exempt
@@ -159,7 +168,7 @@ def Descargar_Ticket(request):
                     </div>
                         <hr />
                     </div> 
-                    <p class="text-small"> Estimado cliente, el siguiente ticket es válido hasta la fecha en la que su mesa fue reservada. No nos hacemos responsables de reclamos o devoluciones después de la fecha estimada.¡Gracias por su atención! Para más información, contáctenos a nuestro número +569 5431 9275.</p>
+                    <p class="text-small"> Estimado cliente, el siguiente ticket es válido hasta la fecha en la que su mesa fue reservada. No nos hacemos responsables de reclamos o devoluciones después de la fecha estimada.¡Gracias por su atención! Para más información, contáctenos a nuestro número +569 1111 1111.</p>
                     </div>
                         <hr />
                     </div>                                          

--- a/ecommerce/templates/reservaciones/reservacion.html
+++ b/ecommerce/templates/reservaciones/reservacion.html
@@ -16,6 +16,13 @@
       </div>
     {% endif %}
 
+    <!-- Notificación de error por correo ya registrado -->
+    {% if request.GET.error == 'correo_existente' %}
+      <div class="container mx_auto alert alert-warning" role="alert" style="max-width: 600px; margin-top: 20px;">
+        ¡Lo sentimos! Ya has hecho una reserva anteriormente con este correo electrónico.
+      </div>
+    {% endif %}
+
     <div class="card mx-auto" style="max-width: 600px; margin-top: 50px;">
         {% include 'includes/alerts.html' %}
 
@@ -44,7 +51,8 @@
                     </div>
                     <div class="col">
                         <label for="telefono">Ingrese su número telefónico</label>
-                        <input type="tel" class="form-control" id="telefono" name="telefono" placeholder="912345678" required>
+                        <input type="tel" class="form-control" id="telefono" name="telefono" placeholder="912345678" required pattern="^\d{9}$" maxlength="9" title="El número de teléfono debe tener exactamente 9 dígitos numéricos">
+
                     </div>
                 </div>
 
@@ -103,7 +111,7 @@
 
                 <div class="form-group form-check">
                     <input type="checkbox" class="form-check-input" id="confirmar" name="confirmar" required>
-                    <label class="form-check-label" for="confirmar">Confirmar reserva</label>
+                    <label class="form-check-label" for="confirmar">Estoy de acuerdo con los términos y condiciones del servicio de la Chabelita.</label>
                 </div>
 
                 <button type="submit" class="btn btn-primary btn-block">Reservar mesa</button>
@@ -145,6 +153,15 @@
     document.getElementById('reserva-form').onsubmit = async function (event) {
         event.preventDefault();  // Prevenir el envío normal del formulario
 
+        const telefono = document.getElementById('telefono').value;
+        const telefonoPattern = /^\d{9}$/;
+
+        // Validar si el número de teléfono tiene exactamente 9 dígitos
+        if (!telefonoPattern.test(telefono)) {
+            alert("Por favor, ingrese un número de teléfono válido con exactamente 9 dígitos.");
+            return;  // Detener el envío del formulario si el teléfono no es válido
+        }
+
         const formData = new FormData(this);
         const response = await fetch(this.action, {
             method: 'POST',
@@ -162,7 +179,11 @@
         } else if (data.error === 'mesa_ocupada') {
             // Redirigir en caso de error por mesa ocupada
             window.location.href = "?error=mesa_ocupada";
+        } else if (data.error === 'correo_existente') {
+            // Redirigir en caso de error por correo electrónico ya registrado
+            window.location.href = "?error=correo_existente";
         }
     };
+
 </script>
 {% endblock %}


### PR DESCRIPTION
Caso (CP-041): el sistema de reservaciones ahora no permite correos duplicados.
Formato de número de teléfono (solo permite datos numéricos y los dígitos llegan hasta el 9).
Agregado término y condiciones en el checkbox.